### PR TITLE
Delete raw tags

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,6 +1,6 @@
-{% raw %}<h2>{{ site.data.navigation.docs_list_title }}</h2>
+<h2>{{ site.data.navigation.docs_list_title }}</h2>
 <ul>
    {% for item in site.data.navigation.docs %}
       <li><a href="{{ item.url }}" alt="{{ item.title }}">{{ item.title }}</a></li>
    {% endfor %}
-</ul>{% endraw %}
+</ul>


### PR DESCRIPTION
Raw tags prevent liquid code from being interpreted. It's only useful when you want to display Liquid code on your page, like in documentation examples.